### PR TITLE
Use constant directory name length when parsing psuNames

### DIFF
--- a/split.ps1
+++ b/split.ps1
@@ -4,6 +4,7 @@ $importFolder = ".\import"
 $exportFolder = ".\export"
 $tempFolder = ".\temp"
 $cmd = "$($myMcFolder)\mymc.exe"
+$psuNameMaxLength = 20
 
 Function Confirm-MyMcPresent {
 	$fileExists = Test-Path $cmd
@@ -111,8 +112,7 @@ Function Export-Psus($mcFile) {
 	$saves = New-Object Collections.Generic.List[String]
 	for($i = 0; $i -lt $saveList.Length; $i = $i + 3) {
 		if ($saveList[$i] -match 'S[A-Z][A-Z][A-Z]-\d\d\d\d\d') {
-			$endOfId = $saveList[$i].IndexOf(" ")
-			$psuName = $saveList[$i].Substring(0,$endOfId).Trim()
+			$psuName = $saveList[$i].Substring(0, $psuNameMaxLength).Trim()
 			if($psuName.Length) {
 				$saves.Add($psuName)
 			}


### PR DESCRIPTION
This PR fixes #2

Like mentioned in the PR, some directory names actually contain spaces, so when parsing the psuNames the first space might actually still be part of the path name, for example:

```
BESLES-02111EZ RPG               Ehrgeiz:Dungeon Mode
BESLES-50382 FILE-1              SILENT HILL 2
BESLES-50382 FILE-2              SILENT HILL 2
```

I fixed the issue by using a constant `20` for the Substring end index, which I got from looking at the output of contents of one memory card:

```
BASCUS-94426-SLOTS               CTR:Saved Games and Scores
BASLUS-00707SILENT00             SILENT HILL  FILE01
BASLUS-01071LUNAR2EC             LUNAR 2: SAVE 01 (006:57/007:26)
BASLUS-01115-FARM0               HARVEST MOON FILE1 Yr 1 Spring
BASLUS-01163                     STRIDER2
BASLUS-0125100000-00             FF9/FILE01/25:19
BESCES-00736XEVI3DGP             XEVIOUS 3D/G+  Data.   ??? namco
BESCES-00867FF7-S01              FF7/SAVE01/99:59
BESCES-01833Tennis               ANNA KOURNIKOVAÆS SMASH COURT
BESCES-02380GAME                 GT2 Game File
BESCES-50294GAMEDATA             GT3 Game Data
BESCES-50490FF090600             FF10 [01] 146:26
BESCES-50878Tekken-4             TEKKEN 4
BESCES-50967-02                  KINGDOMHEARTS/02
BESCES-51920SIREN                Forbidden Siren
BESLES-02096-BM                  beatmania
BESLES-02111EZ RPG               Ehrgeiz:Dungeon Mode
BESLES-02558AS8crOzQ             PE2 4:53 Sterilization Rm.(2)
BESLES-03221-DINO200             DINO CRISIS2 NO.01 [01:55:31]
BESLES-03778                     MegamanX6
BESLES-50078-TS1-OPT             TimeSplitters
BESLES-50111                     Zone Of The
BESLES-50112shadow_e             Shadow of
BESLES-50247                     ONIMUSHA
BESLES-50306                     RESIDENT EVIL
BESLES-50330GTA30000             GTA3
BESLES-50358                     Devil May Cry
BESLES-50382 FILE-1              SILENT HILL 2
BESLES-50382 FILE-2              SILENT HILL 2
BESLES-50383000G000              MGS2-00/ 1:05:47
BESLES-50383000G001              MGS2-01/ 2:22:32
BESLES-50383000G002              MGS2-02/ 5:12:41
BESLES-50430                     ESPN X Games
BESLES-50435naaproia             THPS3 Options
BESLES-50504SYSTEM               Half-Life
BESLES-50877-TS2-OPT             TimeSplitters 2
BESLES-51061GTA40000             GTA ViceCity
BESLES-51349                     Evolution
BESLES-51434File                 SILENT HILL 3
BESLES-51589NETBIO               RESIDENT EVIL
BESLES-51843WORMS3D              WORMS3D
BESLES-51848lijzxgja             THUG Skater:
BESLES-51918S00                  Prince Of Persia
BESLES-51967NFSU                 Need for Speed
BESLES-52541GTA50000             SanAndreas
BESLES-52584                     Burnout 3
BESLES-53038DMC3                 DEVIL MAY CRY 3
BESLES-54185000                  DC -FFVII-
BESLES-82011                     Devil May Cry 2
BESLES-820132P000001             MGS3 PHOTO DATA
```

I assume that the 20 character limit is hard coded, but I could be wrong there too... alternative fix would be using a similar heuristics as the previous solution but instead using something like `           ` to split the string or the column where the filenames align. 