### PR TITLE
Fix Issue #4 for real

### DIFF
--- a/split.ps1
+++ b/split.ps1
@@ -122,9 +122,16 @@ Function Export-Psus($mcFile) {
 	
 	if($saves.Length) {
 		foreach($save in $saves) {
+			$sanitizedFileName = $save.Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
+			$counter = 1
 			Write-Output "Found $($save) in $($mcFile.BaseName)..."
-			$prm = "$($tempFolder)\$($mcFile.Name)", "export", $save
+			$prm = "$($tempFolder)\$($mcFile.Name)", "export", "-o $($sanitizedFileName).psu", $save
 			& $cmd $prm
+			while ( $LASTEXITCODE ) {
+				$prm = "$($tempFolder)\$($mcFile.Name)", "export", "-o $($sanitizedFileName)-$($counter).psu", $save
+				& $cmd $prm
+				$counter++
+			}
 		}
 	}
 	Move-PsuFromRootDir

--- a/split.ps1
+++ b/split.ps1
@@ -5,6 +5,7 @@ $exportFolder = ".\export"
 $tempFolder = ".\temp"
 $cmd = "$($myMcFolder)\mymc.exe"
 $psuNameMaxLength = 32
+$gameIdRegex = 'S[A-Z]{3}-\d{5}'
 
 Function Confirm-MyMcPresent {
 	$fileExists = Test-Path $cmd
@@ -111,7 +112,7 @@ Function Export-Psus($mcFile) {
 	}
 	$saves = New-Object Collections.Generic.List[String]
 	for($i = 0; $i -lt $saveList.Length; $i = $i + 3) {
-		if ($saveList[$i] -match 'S[A-Z][A-Z][A-Z]-\d\d\d\d\d') {
+		if ($saveList[$i] -match $gameIdRegex) {
 			$psuName = $saveList[$i].Substring(0, $psuNameMaxLength).Trim()
 			if($psuName.Length) {
 				$saves.Add($psuName)
@@ -158,7 +159,7 @@ Function Get-PsuWithGameId($saveFile) {
 Function Repair-SavesWithNoGameId {
 	$saveFiles = Get-ChildItem -Path "$($tempFolder)\*" -Include ('*.psu','*.xps','*.max','*.cbs','*.sps')
 	foreach($saveFile in $saveFiles) {
-		if(!($saveFile.BaseName -match 'S[A-Z][A-Z][A-Z]-\d\d\d\d\d')) {
+		if(!($saveFile.BaseName -match $gameIdRegex)) {
 			Get-PsuWithGameId($saveFile)
 			Remove-Item -Path (Join-Path $saveFile.Directory $saveFile.Name)
 		}
@@ -208,7 +209,7 @@ Function New-Vmcs {
 
 	foreach($saveFile in $saveFiles) {
 		$channelNum = 1
-		if($saveFile.BaseName -match 'S[A-Z][A-Z][A-Z]-\d\d\d\d\d') {
+		if($saveFile.BaseName -match $gameIdRegex) {
 			$gameId = $Matches.0
 		} else {
 			Write-Output "Could not find Game ID in $($saveFile.Name)"

--- a/split.ps1
+++ b/split.ps1
@@ -125,13 +125,15 @@ Function Export-Psus($mcFile) {
 			$sanitizedFileName = $save.Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
 			$counter = 1
 			Write-Output "Found $($save) in $($mcFile.BaseName)..."
-			$prm = "$($tempFolder)\$($mcFile.Name)", "export", "-o $($sanitizedFileName).psu", $save
-			& $cmd $prm
-			while ( $LASTEXITCODE ) {
-				$prm = "$($tempFolder)\$($mcFile.Name)", "export", "-o $($sanitizedFileName)-$($counter).psu", $save
-				& $cmd $prm
-				$counter++
+			if(Test-Path -Path "$($sanitizedFileName).psu" -PathType Leaf) {
+				while(Test-Path -Path "$($sanitizedFileName)-$($counter).psu" -PathType Leaf) {
+					$counter++
+				}
+				$prm = "$($tempFolder)\$($mcFile.Name)", "export", "--output-file=$($sanitizedFileName)-$($counter).psu", $save
+			}else{
+				$prm = "$($tempFolder)\$($mcFile.Name)", "export", "--output-file=$($sanitizedFileName).psu", $save
 			}
+			& $cmd $prm
 		}
 	}
 	Move-PsuFromRootDir


### PR DESCRIPTION
The sample memory card has 2 saves for the same game, I think.  It also causes mymc to try and write a save file that has invalid characters in the file name.  This should take care of both issues.

There's probably a better way to detect mymc throwing the specific File Exists error, but I could not find documentation on how to make Powershell do that.